### PR TITLE
Problem: zdir_new() is not careful with its inputs

### DIFF
--- a/src/zdir.c
+++ b/src/zdir.c
@@ -187,8 +187,24 @@ zdir_new (const char *path, const char *parent)
     }
 #else
     //  Remove any trailing slash
-    if (self->path [strlen (self->path) - 1] == '/')
-        self->path [strlen (self->path) - 1] = 0;
+    {
+        size_t l = strlen (self->path);
+
+        while (l > 0) {
+            if ( (l == 1) && self->path [0] == '/')
+                // The whole path is root, skip its trimming
+                break;
+
+            if (self->path [l - 1] == '/') {
+                self->path [l - 1] = '\0';
+            } else {
+                // Last char is not slash
+                break;
+            }
+            l--;
+        }
+        assert (l > 0); // path should not be empty
+    }
 
     DIR *handle = opendir (self->path);
     if (handle) {


### PR DESCRIPTION
Solutions:
* check for NULL arguments before using them
* check for empty `path` when it is the full path (parent is `-`)
** note: empty path and empty parent implicitly means rootfs here; should it?.. actually empty parent seems not checked at all
** note: empty path and non-empty parent resolves into parent, this looks right
* do not cut the trailing slash of the root dir (`path == /`)
* cut multiple trailing slashes, not just one