### PR TITLE
[WIP] zdir.c : zdir_new() : make sure all inputs are valid

### DIFF
--- a/src/zdir.c
+++ b/src/zdir.c
@@ -119,9 +119,17 @@ zdir_new (const char *path, const char *parent)
     zdir_t *self = (zdir_t *) zmalloc (sizeof (zdir_t));
     if (!self)
         return NULL;
+    if (!path)
+        return NULL;
+    if (!parent)
+        return NULL;
 
     if (parent) {
         if (streq (parent, "-")) {
+            if (streq (path, "")) {
+                zdir_destroy (&self);
+                return NULL;
+            }
             self->trimmed = true;
             self->path = strdup (path);
             if (!self->path) {


### PR DESCRIPTION
Solutions:
* check for NULL arguments before using them
* check for empty `path` when it is the full path (parent is `-`)
** note: empty path and empty parent implicitly means rootfs here; should it?.. actually empty parent seems not checked at all
** note: empty path and non-empty parent resolves into parent, this looks right

See also https://github.com/zeromq/czmq/pull/1894