### PR TITLE
czmq v3.0.2-FTY improve travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ addons:
     - uuid-dev
 
 env:
+- BUILD_TYPE=default ZMQ_REPO_URL=https://github.com/42ity/libzmq.git
+- BUILD_TYPE=default ZMQ_REPO_URL=https://github.com/42ity/libzmq.git WITH_LIBSODIUM=1
 #- BUILD_TYPE=default ZMQ_REPO=zeromq2-x
 - BUILD_TYPE=default ZMQ_REPO=zeromq3-x
 - BUILD_TYPE=default ZMQ_REPO=zeromq4-x WITH_LIBSODIUM=1
@@ -47,6 +49,27 @@ matrix:
         packages:
         - valgrind
         - uuid-dev
+
+  - env: BUILD_TYPE=valgrind ZMQ_REPO_URL=https://github.com/42ity/libzmq.git
+    os: linux
+    dist: trusty
+    sudo: required
+    addons:
+      apt:
+        packages:
+        - valgrind
+        - uuid-dev
+
+  - env: BUILD_TYPE=valgrind ZMQ_REPO_URL=https://github.com/42ity/libzmq.git WITH_LIBSODIUM=1
+    os: linux
+    dist: trusty
+    sudo: required
+    addons:
+      apt:
+        packages:
+        - valgrind
+        - uuid-dev
+
 #  - env: BUILD_TYPE=valgrind ZMQ_REPO=libzmq WITH_LIBSODIUM=1
 #    os: linux
 #    dist: trusty
@@ -65,6 +88,15 @@ matrix:
       apt:
         packages:
         - uuid-dev
+  - env: BUILD_TYPE=selftest ZMQ_REPO_URL=https://github.com/42ity/libzmq.git ADDRESS_SANITIZER=enabled
+    os: linux
+    dist: trusty
+    sudo: required
+    addons:
+      apt:
+        packages:
+        - uuid-dev
+
   - env: BUILD_TYPE=selftest ZMQ_REPO=zeromq4-x ADDRESS_SANITIZER=enabled WITH_LIBSODIUM=1
     os: linux
     dist: trusty
@@ -73,7 +105,23 @@ matrix:
       apt:
         packages:
         - uuid-dev
-  - env: BUILD_TYPE=selftest ZMQ_REPO=libzmq ADDRESS_SANITIZER=enabled WITH_LIBSODIUM=1
+  - env: BUILD_TYPE=selftest ZMQ_REPO=libzmq ADDRESS_SANITIZER=enabled WITH_LIBSODIUM=1 ZMQ_CONFIG_OPTS_DRAFT=no
+    os: linux
+    dist: trusty
+    sudo: required
+    addons:
+      apt:
+        packages:
+        - uuid-dev
+  - env: BUILD_TYPE=selftest ZMQ_REPO=libzmq ADDRESS_SANITIZER=enabled WITH_LIBSODIUM=1 ZMQ_CONFIG_OPTS_DRAFT=yes
+    os: linux
+    dist: trusty
+    sudo: required
+    addons:
+      apt:
+        packages:
+        - uuid-dev
+  - env: BUILD_TYPE=selftest ZMQ_REPO_URL=https://github.com/42ity/libzmq.git ADDRESS_SANITIZER=enabled WITH_LIBSODIUM=1
     os: linux
     dist: trusty
     sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ addons:
     - uuid-dev
 
 env:
-- BUILD_TYPE=default ZMQ_REPO_URL=https://github.com/42ity/libzmq.git
-- BUILD_TYPE=default ZMQ_REPO_URL=https://github.com/42ity/libzmq.git WITH_LIBSODIUM=1
+- BUILD_TYPE=default ZMQ_REPO_URL=https://github.com/42ity/libzmq.git ZMQ_REPO_BRANCH=4.2.0-FTY-master
+- BUILD_TYPE=default ZMQ_REPO_URL=https://github.com/42ity/libzmq.git ZMQ_REPO_BRANCH=4.2.0-FTY-master WITH_LIBSODIUM=1
 #- BUILD_TYPE=default ZMQ_REPO=zeromq2-x
 - BUILD_TYPE=default ZMQ_REPO=zeromq3-x
 - BUILD_TYPE=default ZMQ_REPO=zeromq4-x WITH_LIBSODIUM=1
@@ -60,7 +60,7 @@ matrix:
         - valgrind
         - uuid-dev
 
-  - env: BUILD_TYPE=valgrind ZMQ_REPO_URL=https://github.com/42ity/libzmq.git WITH_LIBSODIUM=1
+  - env: BUILD_TYPE=valgrind ZMQ_REPO_URL=https://github.com/42ity/libzmq.git ZMQ_REPO_BRANCH=4.2.0-FTY-master WITH_LIBSODIUM=1
     os: linux
     dist: trusty
     sudo: required
@@ -88,7 +88,7 @@ matrix:
       apt:
         packages:
         - uuid-dev
-  - env: BUILD_TYPE=selftest ZMQ_REPO_URL=https://github.com/42ity/libzmq.git ADDRESS_SANITIZER=enabled
+  - env: BUILD_TYPE=selftest ZMQ_REPO_URL=https://github.com/42ity/libzmq.git ZMQ_REPO_BRANCH=4.2.0-FTY-master ADDRESS_SANITIZER=enabled
     os: linux
     dist: trusty
     sudo: required
@@ -105,6 +105,7 @@ matrix:
       apt:
         packages:
         - uuid-dev
+
   - env: BUILD_TYPE=selftest ZMQ_REPO=libzmq ADDRESS_SANITIZER=enabled WITH_LIBSODIUM=1 ZMQ_CONFIG_OPTS_DRAFT=no
     os: linux
     dist: trusty
@@ -121,7 +122,16 @@ matrix:
       apt:
         packages:
         - uuid-dev
-  - env: BUILD_TYPE=selftest ZMQ_REPO_URL=https://github.com/42ity/libzmq.git ADDRESS_SANITIZER=enabled WITH_LIBSODIUM=1
+
+  - env: BUILD_TYPE=selftest ZMQ_REPO_URL=https://github.com/42ity/libzmq.git ZMQ_REPO_BRANCH=4.2.0-FTY-master ADDRESS_SANITIZER=enabled WITH_LIBSODIUM=1
+    os: linux
+    dist: trusty
+    sudo: required
+    addons:
+      apt:
+        packages:
+        - uuid-dev
+  - env: BUILD_TYPE=selftest ZMQ_REPO_URL=https://github.com/42ity/libzmq.git ZMQ_REPO_BRANCH=4.2.0-FTY-master ADDRESS_SANITIZER=enabled WITH_LIBSODIUM=1 LIBSODIUM_REPO_URL=https://github.com/42ity/libsodium.git LIBSODIUM_REPO_BRANCH=1.0.5-FTY-master
     os: linux
     dist: trusty
     sudo: required

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -9,7 +9,7 @@ default|valgrind|selftest)
     fi
 
     # Build, check, and install libsodium if WITH_LIBSODIUM is set
-    if [ -n "$WITH_LIBSODIUM" ]; then
+    if [ "$WITH_LIBSODIUM" = 1 ]; then
         echo "==== BUILD LIBSODIUM ===="
 #        git clone git://github.com/jedisct1/libsodium.git &&
         git clone -b stable git://github.com/jedisct1/libsodium.git &&

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -10,7 +10,7 @@ default|valgrind|selftest)
 
     # Build, check, and install libsodium if WITH_LIBSODIUM is set
     if [ "$WITH_LIBSODIUM" = 1 ]; then
-        echo "==== BUILD LIBSODIUM ===="
+        echo "==== BUILD LIBSODIUM from git://github.com/jedisct1/libsodium.git stable branch ===="
 #        git clone git://github.com/jedisct1/libsodium.git &&
         git clone -b stable git://github.com/jedisct1/libsodium.git &&
         ( cd libsodium; ./autogen.sh && ./configure "${CONFIG_OPTS[@]}" &&
@@ -24,7 +24,7 @@ default|valgrind|selftest)
         make check && sudo make install && sudo ldconfig ) || exit 1
 
     # Build, check, and install CZMQ from local source
-    echo "==== BUILD LIBCZMQ (current project) ===="
+    echo "==== BUILD LIBCZMQ (current project checkout) ===="
     ./autogen.sh && ./configure "${CONFIG_OPTS[@]}" && \
     case "$BUILD_TYPE" in
         default) make check-verbose VERBOSE=1 && sudo make install ;;

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -13,18 +13,19 @@ default|valgrind|selftest)
         echo "==== BUILD LIBSODIUM from git://github.com/jedisct1/libsodium.git stable branch ===="
 #        git clone git://github.com/jedisct1/libsodium.git &&
         git clone -b stable git://github.com/jedisct1/libsodium.git &&
-        ( cd libsodium; ./autogen.sh && ./configure "${CONFIG_OPTS[@]}" &&
+        ( cd libsodium; git rev-parse HEAD; ./autogen.sh && ./configure "${CONFIG_OPTS[@]}" &&
             make check && sudo make install && sudo ldconfig ) || exit 1
     fi
 
     # Build, check, and install the version of ZeroMQ given by ZMQ_REPO
     echo "==== BUILD LIBZMQ from git://github.com/zeromq/${ZMQ_REPO}.git ===="
     git clone git://github.com/zeromq/${ZMQ_REPO}.git &&
-    ( cd ${ZMQ_REPO}; ./autogen.sh && ./configure "${CONFIG_OPTS[@]}" &&
+    ( cd ${ZMQ_REPO}; git rev-parse HEAD; ./autogen.sh && ./configure "${CONFIG_OPTS[@]}" &&
         make check && sudo make install && sudo ldconfig ) || exit 1
 
     # Build, check, and install CZMQ from local source
     echo "==== BUILD LIBCZMQ (current project checkout) ===="
+    git rev-parse HEAD
     ./autogen.sh && ./configure "${CONFIG_OPTS[@]}" && \
     case "$BUILD_TYPE" in
         default) make check-verbose VERBOSE=1 && sudo make install ;;

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -40,6 +40,7 @@ default|valgrind|selftest)
     git clone ${ZMQ_REPO_URL} ${ZMQ_REPO} &&
     ( cd ${ZMQ_REPO}
         if [ -n "$ZMQ_REPO_BRANCH" ] ; then git checkout "$ZMQ_REPO_BRANCH" ; fi
+        if [ "$WITH_LIBSODIUM" = 1 ]; then CONFIG_OPTS+=("--with-libsodium=yes") ; else CONFIG_OPTS+=("--with-libsodium=no") ; fi
         git rev-parse HEAD; ./autogen.sh && ./configure "${CONFIG_OPTS[@]}" --enable-drafts="${ZMQ_CONFIG_OPTS_DRAFT}" &&
         make check && sudo make install && sudo ldconfig ) || exit 1
 

--- a/src/zconfig.c
+++ b/src/zconfig.c
@@ -683,18 +683,11 @@ static int
 s_collect_level (char **start, int lineno)
 {
     char *readptr = *start;
-    int spaces = 0;
-    int tabs = 0;
-    while (*readptr == ' ' || *readptr == '\t') {
-        if (*readptr == ' ')
-            spaces++;
-        else
-            tabs++;
+    while (*readptr == ' ')
         readptr++;
-    }
-    ptrdiff_t level = (spaces + 4*tabs) / 4;
-    if (level * 4 != spaces + 4*tabs) {
-        zclock_log ("E (zconfig): (%d) indent 4 spaces at once or use tabs", lineno);
+    ptrdiff_t level = (readptr - *start) / 4;
+    if (level * 4 != readptr - *start) {
+        zclock_log ("E (zconfig): (%d) indent 4 spaces at once", lineno);
         level = -1;
     }
     *start = readptr;

--- a/src/zconfig.c
+++ b/src/zconfig.c
@@ -683,11 +683,18 @@ static int
 s_collect_level (char **start, int lineno)
 {
     char *readptr = *start;
-    while (*readptr == ' ')
+    int spaces = 0;
+    int tabs = 0;
+    while (*readptr == ' ' || *readptr == '\t') {
+        if (*readptr == ' ')
+            spaces++;
+        else
+            tabs++;
         readptr++;
-    ptrdiff_t level = (readptr - *start) / 4;
-    if (level * 4 != readptr - *start) {
-        zclock_log ("E (zconfig): (%d) indent 4 spaces at once", lineno);
+    }
+    ptrdiff_t level = (spaces + 4*tabs) / 4;
+    if (level * 4 != spaces + 4*tabs) {
+        zclock_log ("E (zconfig): (%d) indent 4 spaces at once or use tabs", lineno);
         level = -1;
     }
     *start = readptr;

--- a/src/zsock_option.c
+++ b/src/zsock_option.c
@@ -1345,7 +1345,20 @@ zsock_set_sndtimeo (void *self, int sndtimeo)
 #   if defined (ZMQ_SNDTIMEO)
     int rc = zmq_setsockopt (zsock_resolve (self), ZMQ_SNDTIMEO, &sndtimeo, sizeof (int));
     if (rc == -1 && sndtimeo == 0)
-        zsys_warning ("%s: rc=%d, sndtimeo=%d, zmq_errno ()=%d, zsys_interrupted=%d\nassert suppressed, this is OK in case of shutdown\n", __FUNCTION__, sndtimeo, zmq_errno (), zsys_interrupted);
+        zsys_warning ("%s: rc=%d, sndtimeo=%d, zmq_errno ()=%d, zsys_interrupted=%d\nassert suppressed, this is OK in case of shutdown\n",
+// Generated code amended here to avoid non-portable __FUNCTION__ macro
+// wherever pedantic compilers (gcc5+) complain. Not an issue with the
+// upstream czmq because it obsoleted and remade this part of codebase.
+#       if defined (__FUNCTION__)
+            __FUNCTION__,
+#       else
+#           if defined (__func__)
+            __func__,
+#           else
+            "zsock_set_sndtimeo()",
+#           endif
+#       endif
+            sndtimeo, zmq_errno (), zsys_interrupted);
     else
         assert (rc == 0 || zmq_errno () == ETERM);
 #   endif


### PR DESCRIPTION
* Test the 42ity fork of czmq against 42ity forks of libzmq and libsodium as well.
* Report the dependencies built for this test.
* Trying to research the faults in tests with libsodium against upstream libzmq (split with/without draft builds per IRC suggestion).