### PR TITLE
Problem: build error with GCC7 in zgossip_engine.inc

### DIFF
--- a/src/zgossip_engine.inc
+++ b/src/zgossip_engine.inc
@@ -258,7 +258,7 @@ engine_set_log_prefix (client_t *client, const char *string)
 {
     if (client) {
         s_client_t *self = (s_client_t *) client;
-        snprintf (self->log_prefix, sizeof (self->log_prefix) - 1,
+        snprintf (self->log_prefix, sizeof (self->log_prefix),
             "%6d:%-33s", self->unique_id, string);
     }
 }


### PR DESCRIPTION
Solution: snprintf size parameter includes the NULL terminating char
as the manpage says, so don't pass sizeof(..) - 1