### PR TITLE
Do not fail OBS packaging with Debian 10 anymore

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,12 +12,12 @@ addons:
     - uuid-dev
 
 env:
-- BUILD_TYPE=default ZMQ_REPO_URL=https://github.com/42ity/libzmq.git ZMQ_REPO_BRANCH=4.2.0-FTY-master
-- BUILD_TYPE=default ZMQ_REPO_URL=https://github.com/42ity/libzmq.git ZMQ_REPO_BRANCH=4.2.0-FTY-master WITH_LIBSODIUM=1
-#- BUILD_TYPE=default ZMQ_REPO=zeromq2-x
-- BUILD_TYPE=default ZMQ_REPO=zeromq3-x
-- BUILD_TYPE=default ZMQ_REPO=zeromq4-x WITH_LIBSODIUM=1
-- BUILD_TYPE=default ZMQ_REPO=libzmq    WITH_LIBSODIUM=1
+- BUILD_TYPE=default-Werror ZMQ_REPO_URL=https://github.com/42ity/libzmq.git ZMQ_REPO_BRANCH=4.2.0-FTY-master
+- BUILD_TYPE=default-Werror ZMQ_REPO_URL=https://github.com/42ity/libzmq.git ZMQ_REPO_BRANCH=4.2.0-FTY-master WITH_LIBSODIUM=1
+#- BUILD_TYPE=default-Werror ZMQ_REPO=zeromq2-x
+- BUILD_TYPE=default-Werror ZMQ_REPO=zeromq3-x
+- BUILD_TYPE=default-Werror ZMQ_REPO=zeromq4-x WITH_LIBSODIUM=1
+- BUILD_TYPE=default-Werror ZMQ_REPO=libzmq    WITH_LIBSODIUM=1
 #- BUILD_TYPE=valgrind ZMQ_REPO=zeromq2-x
 #- BUILD_TYPE=valgrind ZMQ_REPO=zeromq3-x
 #- BUILD_TYPE=valgrind ZMQ_REPO=zeromq4-x WITH_LIBSODIUM=1

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -53,10 +53,10 @@ default|default-Werror|valgrind|selftest)
     git rev-parse HEAD
     ./autogen.sh && ./configure "${CONFIG_OPTS[@]}" && \
     case "$BUILD_TYPE" in
-        default) make check-verbose VERBOSE=1 && sudo make install ;;
+        default|default-Werror) make check-verbose VERBOSE=1 && sudo make install ;;
         selftest) ASAN_OPTIONS=verbosity=1 make check-verbose ;;
         valgrind) make memcheck ;;
-        *) echo "Unknown BUILD_TYPE" 2>&1; false ;;
+        *) echo "Unknown BUILD_TYPE: '$BUILD_TYPE'" 2>&1; false ;;
     esac
     ;;
 *)

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -2,7 +2,7 @@
 
 case "$BUILD_TYPE" in
 "") echo "BUILD_TYPE is not set!" >&2 ; false ;;
-default|valgrind|selftest)
+default|default-Werror|valgrind|selftest)
     CONFIG_OPTS=()
     if [ -n "$ADDRESS_SANITIZER" ] && [ "$ADDRESS_SANITIZER" == "enabled" ]; then
         CONFIG_OPTS+=("--enable-address-sanitizer=yes")
@@ -43,6 +43,10 @@ default|valgrind|selftest)
         if [ "$WITH_LIBSODIUM" = 1 ]; then CONFIG_OPTS+=("--with-libsodium=yes") ; else CONFIG_OPTS+=("--with-libsodium=no") ; fi
         git rev-parse HEAD; ./autogen.sh && ./configure "${CONFIG_OPTS[@]}" --enable-drafts="${ZMQ_CONFIG_OPTS_DRAFT}" &&
         make check && sudo make install && sudo ldconfig ) || exit 1
+
+    if [ "$BUILD_TYPE" == "default-Werror" ]; then
+        CONFIG_OPTS+=("--enable-Werror")
+    fi
 
     # Build, check, and install CZMQ from local source
     echo "==== BUILD LIBCZMQ (current project checkout) ===="

--- a/configure.ac
+++ b/configure.ac
@@ -304,10 +304,44 @@ AC_TYPE_UINT32_T
 AC_C_VOLATILE
 AC_C_BIGENDIAN
 
+AC_ARG_ENABLE([Werror],
+    AS_HELP_STRING([--enable-Werror],
+        [Add -Wall -Werror to GCC/GXX arguments [default=no; default=auto if nothing specified as the specific argument value]]),
+    [AS_IF([test -n "$enableval"], [enable_Werror=$enableval], [enable_Werror=auto])],
+    [enable_Werror=no])
+
 # These options are GNU compiler specific.
-if test "x$GCC" = "xyes"; then
-    CPPFLAGS="-pedantic -Werror -Wall -Wc++-compat ${CPPFLAGS}"
-fi
+AS_IF([test "x$enable_Werror" = "xyes" || test "x$enable_Werror" = "xauto"],
+    [AS_IF([test -n "$CC"],[AS_IF([$CC --version 2>&1 | grep 'Free Software Foundation' > /dev/null && test "x$GCC" = "xyes"],
+        [AC_MSG_NOTICE([Enabling pedantic errors for GNU C])
+         CFLAGS="$CFLAGS -pedantic -Wall -Werror -Werror=format-security"],
+        [AS_IF([$CC --version 2>&1 | grep 'clang version' > /dev/null],
+            [AC_MSG_NOTICE([Enabling pedantic errors for clang C])
+             CFLAGS="$CFLAGS -pedantic -Wall -Werror -Werror=format-security"],
+            [AC_MSG_NOTICE([Not enabling pedantic errors: compiler not supported by this recipe (not GNU or clang C)])
+             AS_IF([test "x$enable_Werror" = "xyes"], [AC_MSG_ERROR([--enable-Werror=yes was requested and can not be satisfied for C: $CC])])
+        ])])])
+     AS_IF([test -n "$CXX"],[AS_IF([$CXX --version 2>&1 | grep 'Free Software Foundation' > /dev/null && test "x$GCC" = "xyes"],
+        [AC_MSG_NOTICE([Enabling pedantic errors for GNU C++])
+         CXXFLAGS="$CXXFLAGS -pedantic -Wall -Werror -Werror=format-security"],
+        [AS_IF([$CXX --version 2>&1 | grep 'clang version' > /dev/null],
+            [AC_MSG_NOTICE([Enabling pedantic errors for clang C++])
+             CXXFLAGS="$CXXFLAGS -pedantic -Wall -Werror -Werror=format-security"],
+            [AC_MSG_NOTICE([Not enabling pedantic errors: compiler not supported by this recipe (not GNU or clang C++)])
+             AS_IF([test "x$enable_Werror" = "xyes"], [AC_MSG_ERROR([--enable-Werror=yes was requested and can not be satisfied for C++: $CXX])])
+        ])])])
+     AS_IF([test -n "$CPP"],[AS_IF([$CPP --version 2>&1 | grep 'Free Software Foundation' > /dev/null && test "x$GCC" = "xyes"],
+        [AC_MSG_NOTICE([Enabling pedantic errors for GNU CPP preprocessor])
+         CPPFLAGS="$CPPFLAGS -pedantic -Werror -Wall -Wc++-compat"
+        ],
+        [AS_IF([$CXX --version 2>&1 | grep 'clang version' > /dev/null],
+            [AC_MSG_NOTICE([Enabling pedantic errors for clang CPP preprocessor])
+             CPPFLAGS="$CPPFLAGS -pedantic -Werror -Wall -Wc++-compat"
+            ],
+            [AC_MSG_NOTICE([Not enabling pedantic errors: preprocessor not supported by this recipe (not GNU or clang CPP)])
+             AS_IF([test "x$enable_Werror" = "xyes"], [AC_MSG_ERROR([--enable-Werror=yes was requested and can not be satisfied for CPP: $CPP])])
+        ])])])
+])
 
 AM_CONDITIONAL(ENABLE_SHARED, test "x$enable_shared" = "xyes")
 AM_CONDITIONAL(ON_MINGW, test "x$czmq_on_mingw32" = "xyes")

--- a/src/zgossip_msg.c
+++ b/src/zgossip_msg.c
@@ -542,7 +542,12 @@ zgossip_msg_set_key (zgossip_msg_t *self, const char *value)
     assert (value);
     if (value == self->key)
         return;
+#pragma GCC diagnostic push
+#if __GNUC__ >= 8
+#pragma GCC diagnostic ignored "-Wstringop-truncation"
+#endif
     strncpy (self->key, value, 255);
+#pragma GCC diagnostic pop
     self->key [255] = 0;
 }
 

--- a/src/zuuid.c
+++ b/src/zuuid.c
@@ -214,20 +214,16 @@ zuuid_str_canonical (zuuid_t *self)
     if (!self->str_canonical)
         self->str_canonical = (char *) zmalloc (8 + 4 + 4 + 4 + 12 + 5);
     *self->str_canonical = 0;
-#pragma GCC diagnostic push
-#if __GNUC__ >= 8
-#pragma GCC diagnostic ignored "-Wstringop-truncation"
-#endif
-    strncat (self->str_canonical, self->str, 8);
-    strcat  (self->str_canonical, "-");
-    strncat (self->str_canonical, self->str + 8, 4);
-    strcat  (self->str_canonical, "-");
-    strncat (self->str_canonical, self->str + 12, 4);
-    strcat  (self->str_canonical, "-");
-    strncat (self->str_canonical, self->str + 16, 4);
-    strcat  (self->str_canonical, "-");
-    strncat (self->str_canonical, self->str + 20, 12);
-#pragma GCC diagnostic pop
+    memcpy (self->str_canonical, self->str, 8);
+    self->str_canonical[8] = '-';
+    memcpy (self->str_canonical + 9, self->str + 8, 4);
+    self->str_canonical[13] = '-';
+    memcpy (self->str_canonical + 14, self->str + 12, 4);
+    self->str_canonical[18] = '-';
+    memcpy (self->str_canonical + 19, self->str + 16, 4);
+    self->str_canonical[23] = '-';
+    memcpy (self->str_canonical + 24, self->str + 20, 12);
+    self->str_canonical[36] = '\0';
 
     int char_nbr;
     for (char_nbr = 0; char_nbr < 36; char_nbr++)

--- a/src/zuuid.c
+++ b/src/zuuid.c
@@ -214,6 +214,10 @@ zuuid_str_canonical (zuuid_t *self)
     if (!self->str_canonical)
         self->str_canonical = (char *) zmalloc (8 + 4 + 4 + 4 + 12 + 5);
     *self->str_canonical = 0;
+#pragma GCC diagnostic push
+#if __GNUC__ >= 8
+#pragma GCC diagnostic ignored "-Wstringop-truncation"
+#endif
     strncat (self->str_canonical, self->str, 8);
     strcat  (self->str_canonical, "-");
     strncat (self->str_canonical, self->str + 8, 4);
@@ -223,6 +227,7 @@ zuuid_str_canonical (zuuid_t *self)
     strncat (self->str_canonical, self->str + 16, 4);
     strcat  (self->str_canonical, "-");
     strncat (self->str_canonical, self->str + 20, 12);
+#pragma GCC diagnostic pop
 
     int char_nbr;
     for (char_nbr = 0; char_nbr < 36; char_nbr++)


### PR DESCRIPTION
Our old fork produces some warnings with GCC 8 in Debian 10.

For one, update the `configure.ac` pattern to make the `gcc -Werror -Wall` optional like in other (newer) components, and also try to disable this particular warning about intentional activity in the codebase.